### PR TITLE
Support now()

### DIFF
--- a/src/Flash.php
+++ b/src/Flash.php
@@ -6,10 +6,12 @@ class Flash
 {
     protected $type;
     protected $message;
+    protected $now;
 
-    protected function __construct($message = null)
+    protected function __construct($message = null, $now = false)
     {
         $this->message = $message;
+        $this->now = $now;
 
         $this->putFlash('success');
     }
@@ -24,6 +26,13 @@ class Flash
     public static function instance($message = null)
     {
         return new static($message);
+    }
+
+    public function now(bool $now = true)
+    {
+        $this->now = $now;
+
+        return $this;
     }
 
     /**
@@ -184,7 +193,11 @@ class Flash
 
     protected function flash(array $notifications)
     {
-        session()->now($this->key(), $notifications);
+        if ($this->now) {
+            session()->now($this->key(), $notifications);
+        } else {
+            session()->flash($this->key(), $notifications);
+        }
     }
 
     protected function notifications()


### PR DESCRIPTION
## How it works now

### With `return view()`
#### Flashes for current request
```php
flash()->now()->success('yay!');
return view('welcome');
```

```php
flash('yay!', true);
return view('welcome');
```

#### Flashes for current AND next request
```php
flash()->success('yay!');
return view('welcome');
```
```php
flash('yay!');
return view('welcome');
```
### With `return redirect()`
#### Flashes for current request
```php
flash()->success('yay!');
return redirect('/dashboard');
```

```php
flash('yay!');
return redirect('/dashboard');
```
#### Doesn't work
```php
flash()->now()->success('yay!');
return redirect('/dashboard');
```

```php
flash('yay!', true);
return redirect('/dashboard');
```